### PR TITLE
feat: 新增多项功能并优化现有逻辑

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -105,6 +105,11 @@
     "type": "int",
     "default": 30
   },
+  "cross_group_max_age_hours": {
+    "description": "跨群聊记忆：注入 LLM 时只保留最近多少小时内的记录（0 表示不限时效，仅按条数裁剪，即旧版行为；建议 12~48）",
+    "type": "int",
+    "default": 0
+  },
   "group_switch_enable": {
     "description": "启用「按群聊独立开关插件」功能。开启后，可用 /开关 命令在单个群聊中关闭/开启本插件全部命令",
     "type": "bool",

--- a/cross_group_memory.py
+++ b/cross_group_memory.py
@@ -4,12 +4,21 @@
 保护读写，与插件内 UserStore/DeviceStore 的持久化风格一致，完全自包含、不依赖
 AstrBot 核心数据库。每个平台实例（platform_id）一份独立的记录列表，同平台下所有
 群聊共享这份记忆，重启后保留。
+
+记录结构（每条记录为一个 dict）：
+    {"ts": <unix 时间戳:float>, "tag": <话题标签:str|None>, "content": <文本:str>}
+
+兼容旧版本纯字符串记录：加载时自动迁移为 {"ts": 0.0, "tag": None, "content": <原字符串>}，
+迁移后的记录 ts=0.0，因此在启用 max_age_seconds 过滤时会被视为最旧记录，不会异常置顶。
 """
 
 import json
 import os
+import re
 import threading
+import time
 from collections import deque
+from typing import Optional
 
 from astrbot.api import logger
 
@@ -25,7 +34,7 @@ class CrossGroupMemoryStore:
         self._data_dir = data_dir
         self._file_path = os.path.join(data_dir, "currentcortex_cross_group.json")
         self._lock = threading.Lock()
-        # platform_id -> deque[record_line]
+        # platform_id -> deque[dict]，dict 结构见模块 docstring
         self._buffers: dict[str, deque] = {}
         self._ensure_data_dir()
         self._load()
@@ -33,8 +42,24 @@ class CrossGroupMemoryStore:
     def _ensure_data_dir(self) -> None:
         os.makedirs(self._data_dir, exist_ok=True)
 
+    @staticmethod
+    def _normalize_record(item) -> Optional[dict]:
+        """将加载出的原始记录（新/旧格式）规整为标准 dict 结构。"""
+        if isinstance(item, str):
+            # 旧版本纯字符串记录，迁移时间戳记为 0（视为最旧）。
+            return {"ts": 0.0, "tag": None, "content": item}
+        if isinstance(item, dict) and isinstance(item.get("content"), str):
+            ts = item.get("ts", 0.0)
+            if not isinstance(ts, (int, float)):
+                ts = 0.0
+            tag = item.get("tag")
+            if tag is not None and not isinstance(tag, str):
+                tag = None
+            return {"ts": float(ts), "tag": tag, "content": item["content"]}
+        return None
+
     def _load(self) -> None:
-        """从 JSON 文件加载历史记录到内存。"""
+        """从 JSON 文件加载历史记录到内存（自动迁移旧格式）。"""
         if not os.path.exists(self._file_path):
             return
         try:
@@ -46,8 +71,14 @@ class CrossGroupMemoryStore:
                 )
                 return
             for platform_id, records in data.items():
-                if isinstance(records, list):
-                    self._buffers[platform_id] = deque(records)
+                if not isinstance(records, list):
+                    continue
+                normalized = []
+                for item in records:
+                    rec = self._normalize_record(item)
+                    if rec is not None:
+                        normalized.append(rec)
+                self._buffers[platform_id] = deque(normalized)
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"[CrossGroupMemory] 加载历史记忆失败: {e}")
 
@@ -62,33 +93,50 @@ class CrossGroupMemoryStore:
         except OSError as e:
             logger.warning(f"[CrossGroupMemory] 保存记忆失败: {e}")
 
-    def record(self, platform_id: str, content: str, max_records: int) -> None:
+    def record(
+        self,
+        platform_id: str,
+        content: str,
+        max_records: int,
+        tag: Optional[str] = None,
+    ) -> None:
         """追加一条记录并裁剪到 max_records，然后刷盘。
 
         Args:
             platform_id: 平台适配器实例 id（UMO 第一段）。
             content: 已格式化的聊天记录行。
             max_records: 每个平台保留的最大记录数。
+            tag: 可选话题标签，用于 get_recent 按话题过滤；不传则为 None（不分类）。
         """
         with self._lock:
             buf = self._buffers.get(platform_id)
             if buf is None:
                 buf = deque()
                 self._buffers[platform_id] = buf
-            buf.append(content)
+            buf.append({"ts": time.time(), "tag": tag, "content": content})
             while len(buf) > max_records:
                 buf.popleft()
             self._save()
 
-    def get_recent(self, platform_id: str, limit: int) -> list:
+    def get_recent(
+        self,
+        platform_id: str,
+        limit: int,
+        max_age_seconds: Optional[float] = None,
+        tag: Optional[str] = None,
+    ) -> list:
         """返回某平台最近 limit 条记录（时间正序）。
 
         Args:
             platform_id: 平台适配器实例 id。
             limit: 最大返回条数。
+            max_age_seconds: 可选，仅返回该时长内的记录（相对当前时间）；
+                None 表示不做时效过滤（沿用旧行为）。
+            tag: 可选，仅返回该话题标签的记录；None 表示不按话题过滤，
+                返回所有标签（含未打标签）的记录。
 
         Returns:
-            按时间正序排列的记录字符串列表。
+            按时间正序排列的记录字符串列表（仅 content 部分，兼容旧调用方）。
         """
         if limit <= 0:
             return []
@@ -96,7 +144,15 @@ class CrossGroupMemoryStore:
             buf = self._buffers.get(platform_id)
             if not buf:
                 return []
-            return list(buf)[-limit:]
+            records = list(buf)
+
+        if max_age_seconds is not None:
+            cutoff = time.time() - max_age_seconds
+            records = [r for r in records if r["ts"] >= cutoff]
+        if tag is not None:
+            records = [r for r in records if r.get("tag") == tag]
+
+        return [r["content"] for r in records[-limit:]]
 
     def clear(self, platform_id: str) -> int:
         """清空某平台的所有记录。
@@ -114,3 +170,29 @@ class CrossGroupMemoryStore:
                 buf.clear()
             self._save()
             return cnt
+
+    def forget_keyword(self, platform_id: str, keyword: str) -> int:
+        """删除某平台记忆中所有内容包含指定关键词（子串匹配）的记录。
+
+        Args:
+            platform_id: 平台适配器实例 id。
+            keyword: 匹配关键词（子串匹配，大小写不敏感）；空字符串直接返回 0，
+                不做任何删除（避免误传空串清空全部）。
+
+        Returns:
+            被删除的记录数。
+        """
+        keyword = (keyword or "").strip()
+        if not keyword:
+            return 0
+        pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+        with self._lock:
+            buf = self._buffers.get(platform_id)
+            if not buf:
+                return 0
+            kept = deque(r for r in buf if not pattern.search(r["content"]))
+            removed = len(buf) - len(kept)
+            if removed > 0:
+                self._buffers[platform_id] = kept
+                self._save()
+            return removed

--- a/group_switch_store.py
+++ b/group_switch_store.py
@@ -7,12 +7,19 @@
 语义为「黑名单」：未被显式记录的会话视为启用（默认启用），只有被显式禁用的会话
 （set_disabled）才会被守卫处理器拦截。这样既能精准关闭个别群，又不会影响老群或
 新群。
+
+每个被禁用的会话额外记录一个可选的到期时间戳（until）：
+    - until 为 None：永久禁用，需手动 /开关 on 重新启用。
+    - until 为具体时间戳：到期后自动视为启用（懒惰过期，在 is_enabled /
+      list_disabled 调用时惰性清理，不需要额外的定时任务或后台线程）。
 """
 
 import json
 import os
 import threading
-from typing import List
+import time
+from typing import List, Optional
+
 
 from astrbot.api import logger
 
@@ -30,8 +37,8 @@ class GroupSwitchStore:
             data_dir, "currentcortex_group_switch.json"
         )
         self._lock = threading.Lock()
-        # 被禁用的会话集合（unified_msg_origin）
-        self._disabled: set[str] = set()
+        # 被禁用的会话：umo -> until（unix 时间戳；None 表示永久禁用）
+        self._disabled: dict[str, Optional[float]] = {}
         self._ensure_data_dir()
         self._load()
 
@@ -39,7 +46,7 @@ class GroupSwitchStore:
         os.makedirs(self._data_dir, exist_ok=True)
 
     def _load(self) -> None:
-        """从 JSON 文件加载被禁用的会话集合。"""
+        """从 JSON 文件加载被禁用的会话集合（兼容旧版 list 格式）。"""
         if not os.path.exists(self._file_path):
             return
         try:
@@ -48,9 +55,19 @@ class GroupSwitchStore:
             if isinstance(data, dict):
                 disabled = data.get("disabled", [])
                 if isinstance(disabled, list):
-                    self._disabled = {
-                        str(x) for x in disabled if isinstance(x, str)
-                    }
+                    # 旧版本格式：["umo1", "umo2", ...]，均视为永久禁用。
+                    for x in disabled:
+                        if isinstance(x, str):
+                            self._disabled[x] = None
+                elif isinstance(disabled, dict):
+                    # 新版本格式：{"umo1": until|null, ...}
+                    for umo, until in disabled.items():
+                        if not isinstance(umo, str):
+                            continue
+                        if until is None or isinstance(until, (int, float)):
+                            self._disabled[umo] = (
+                                float(until) if until is not None else None
+                            )
             logger.info(
                 f"[GroupSwitch] 已加载 {len(self._disabled)} 个被禁用的会话"
             )
@@ -59,7 +76,7 @@ class GroupSwitchStore:
 
     def _save(self) -> None:
         """将内存镜像刷盘（调用方需持有锁）。"""
-        data = {"disabled": sorted(self._disabled)}
+        data = {"disabled": dict(sorted(self._disabled.items()))}
         tmp_path = self._file_path + ".tmp"
         try:
             with open(tmp_path, "w", encoding="utf-8") as f:
@@ -68,15 +85,39 @@ class GroupSwitchStore:
         except OSError as e:
             logger.warning(f"[GroupSwitch] 保存开关状态失败: {e}")
 
+    def _purge_expired_locked(self) -> bool:
+        """清理已过期的禁用记录（调用方需持有锁）。
+
+        Returns:
+            是否有记录被清理（用于判断是否需要刷盘）。
+        """
+        now = time.time()
+        expired = [
+            umo
+            for umo, until in self._disabled.items()
+            if until is not None and until <= now
+        ]
+        for umo in expired:
+            del self._disabled[umo]
+        return bool(expired)
+
     def is_enabled(self, umo: str) -> bool:
-        """该会话是否启用（未被显式禁用即视为启用）。"""
+        """该会话是否启用（未被显式禁用，或禁用已到期，即视为启用）。"""
         with self._lock:
+            if self._purge_expired_locked():
+                self._save()
             return umo not in self._disabled
 
-    def set_disabled(self, umo: str) -> None:
-        """显式禁用某会话。"""
+    def set_disabled(self, umo: str, duration_seconds: Optional[float] = None) -> None:
+        """显式禁用某会话。
+
+        Args:
+            umo: 会话标识。
+            duration_seconds: 禁用时长（秒）；None 表示永久禁用，需手动重新启用。
+        """
         with self._lock:
-            self._disabled.add(umo)
+            until = time.time() + duration_seconds if duration_seconds else None
+            self._disabled[umo] = until
             self._save()
 
     def set_enabled(self, umo: str) -> bool:
@@ -86,13 +127,41 @@ class GroupSwitchStore:
             是否实际发生了状态变更（即之前确实是禁用状态）。
         """
         with self._lock:
+            self._purge_expired_locked()
             if umo in self._disabled:
-                self._disabled.discard(umo)
+                del self._disabled[umo]
                 self._save()
                 return True
             return False
 
-    def list_disabled(self) -> List[str]:
-        """返回所有被禁用的会话列表（排序后）。"""
+    def get_until(self, umo: str) -> Optional[float]:
+        """返回某会话的禁用到期时间戳；未禁用或永久禁用则分别返回 None。
+
+        调用前建议先用 is_enabled 判断，避免把「已过期」误当「永久禁用」。
+        """
         with self._lock:
-            return sorted(self._disabled)
+            self._purge_expired_locked()
+            return self._disabled.get(umo)
+
+    def list_disabled(self) -> List[str]:
+        """返回所有（未过期）被禁用的会话列表（排序后）。"""
+        with self._lock:
+            if self._purge_expired_locked():
+                self._save()
+            return sorted(self._disabled.keys())
+
+    def list_disabled_detail(self) -> List[dict]:
+        """返回所有（未过期）被禁用会话的详情列表，用于可视化展示。
+
+        Returns:
+            按 umo 排序的列表，每项为
+            ``{"umo": str, "until": float|None, "permanent": bool}``。
+            permanent=True 表示永久禁用；否则 until 为到期 unix 时间戳。
+        """
+        with self._lock:
+            if self._purge_expired_locked():
+                self._save()
+            return [
+                {"umo": umo, "until": until, "permanent": until is None}
+                for umo, until in sorted(self._disabled.items())
+            ]

--- a/main.py
+++ b/main.py
@@ -376,12 +376,14 @@ MEDIA_PARSER_HELP_TEXT = """🔍 媒体内容解析 使用说明
   • 小红书（xiaohongshu）— 笔记图文/视频解析
   • Bilibili（bilibili）— 视频信息及下载链接解析
   • 抖音（douyin）— 短视频解析
+  • 微博（weibo）— 帖子图文/视频解析
 
 📌 基本命令
   /解析 <链接>           自动识别平台并解析内容（别名：/解析）
   /xhs <链接>           解析小红书内容（别名：/小红书）
   /bilibili <链接>      解析B站视频（别名：/B站）
   /douyin <链接>        解析抖音视频（别名：/抖音）
+  /weibo <链接>         解析微博帖子（别名：/微博）
   /解析 help            显示此帮助信息
 
 📌 支持的链接格式
@@ -398,11 +400,17 @@ MEDIA_PARSER_HELP_TEXT = """🔍 媒体内容解析 使用说明
     • https://www.douyin.com/video/xxx
     • https://v.douyin.com/xxx（短链接）
 
+  微博：
+    • https://weibo.com/1234567890/xxxxx
+    • https://m.weibo.cn/detail/xxxxx
+    • https://t.cn/xxxx（短链接）
+
 📌 使用示例
   /解析 https://www.xiaohongshu.com/explore/abc123
   /xhs https://xhslink.com/xxxx
   /bilibili https://www.bilibili.com/video/BV1xx411c7mD
   /douyin https://v.douyin.com/xxxx
+  /weibo https://m.weibo.cn/detail/xxxxx
 
 📌 返回信息
   小红书：
@@ -419,6 +427,11 @@ MEDIA_PARSER_HELP_TEXT = """🔍 媒体内容解析 使用说明
     • 视频标题、作者
     • 点赞、评论、分享数
     • 无水印视频链接
+
+  微博：
+    • 正文、作者
+    • 转发、评论、点赞数
+    • 配图列表 / 视频链接（如有）
 
 ⚠️ 注意事项
   • 请确保链接可公开访问
@@ -1337,13 +1350,18 @@ class CurrentCortexPlugin(Star):
         self._cross_group_inject_cnt = max(
             0, int(config.get("cross_group_inject_cnt", 30))
         )
+        # 0 表示不限时效（沿用旧行为：只按条数裁剪，不管新旧）
+        self._cross_group_max_age_hours = max(
+            0.0, float(config.get("cross_group_max_age_hours", 0))
+        )
         self._cross_group_store: "CrossGroupMemoryStore | None" = None
         if self._cross_group_enable:
             try:
                 self._cross_group_store = CrossGroupMemoryStore(data_dir="data")
                 logger.info(
                     f"[CrossGroupMemory] 已启用跨群聊记忆 "
-                    f"(max_cnt={self._cross_group_max_cnt}, inject_cnt={self._cross_group_inject_cnt})"
+                    f"(max_cnt={self._cross_group_max_cnt}, inject_cnt={self._cross_group_inject_cnt}, "
+                    f"max_age_hours={self._cross_group_max_age_hours or '不限'})"
                 )
             except Exception as e:
                 logger.warning(f"[CrossGroupMemory] 初始化失败，已禁用: {e}")
@@ -1532,23 +1550,40 @@ class CurrentCortexPlugin(Star):
 
         if action == "status":
             state = "✅ 已启用" if currently_enabled else "⛔ 已关闭"
+            extra = ""
+            if not currently_enabled:
+                until = self._group_switch_store.get_until(umo)
+                extra = (
+                    "\n" + self._format_switch_until(until)
+                    if until is not None
+                    else "\n⏳ 永久禁用（需手动 /开关 on 恢复）"
+                )
             yield event.plain_result(
-                f"🔌 本群插件状态\n{state}\n\n"
+                f"🔌 本群插件状态\n{state}{extra}\n\n"
                 "💡 用法：\n"
-                "  /开关 off  关闭本群全部插件命令\n"
+                "  /开关 off [时长]  关闭本群全部插件命令（可选时长如 2h/30m/1d）\n"
                 "  /开关 on   重新启用"
             )
             return
 
         if action == "off":
+            duration = self._parse_switch_duration(message_str)
             if not currently_enabled:
                 yield event.plain_result("ℹ️ 本群插件已经是关闭状态")
                 return
-            self._group_switch_store.set_disabled(umo)
-            logger.info(f"[GroupSwitch] 用户 {user_name} 关闭了会话 {umo} 的插件")
+            self._group_switch_store.set_disabled(umo, duration_seconds=duration)
+            logger.info(
+                f"[GroupSwitch] 用户 {user_name} 关闭了会话 {umo} 的插件"
+                + (f"（{duration:.0f}秒后自动恢复）" if duration else "（永久）")
+            )
+            recover_hint = (
+                self._format_switch_until(time.time() + duration)
+                if duration
+                else "💡 重新启用：发送 /开关 on"
+            )
             yield event.plain_result(
                 "⛔ 已在本群关闭 CurrentCortex 插件全部命令\n\n"
-                "💡 重新启用：发送 /开关 on\n"
+                f"{recover_hint}\n"
                 "（开关命令始终可用，不会被拦截）"
             )
             return
@@ -1569,10 +1604,42 @@ class CurrentCortexPlugin(Star):
         yield event.plain_result(
             f"🔌 本群插件状态：{state}\n\n"
             "💡 用法：\n"
-            "  /开关 off（或 关）  关闭本群全部插件命令\n"
+            "  /开关 off（或 关）[时长]  关闭本群全部插件命令，可选时长如 2h/30m/1d\n"
             "  /开关 on（或 开）   重新启用\n"
             "  /开关 status（或 状态）  查看当前状态"
         )
+
+    @filter.command("开关列表", alias={"switch_list", "开关状态列表"})
+    async def group_switch_list_command(self, event: AstrMessageEvent):
+        """查看当前平台下所有被关闭插件的群聊（可视化管理，仅管理员可用）。
+
+        以文本表格形式列出各被禁用会话及其恢复时间，方便管理员一眼确认插件在
+        哪些群处于关闭状态，无需逐个群发送 /开关 status 查询。
+        """
+        if not self._group_switch_enable or self._group_switch_store is None:
+            yield event.plain_result(
+                "❌ 按群聊开关功能未启用\n"
+                "💡 请在插件配置中开启 group_switch_enable 后重启插件"
+            )
+            return
+
+        if self._group_switch_admin_only and not event.is_admin():
+            yield event.plain_result("❌ 仅管理员可查看开关列表")
+            return
+
+        details = self._group_switch_store.list_disabled_detail()
+        if not details:
+            yield event.plain_result("✅ 当前没有被关闭插件的群聊")
+            return
+
+        lines = [f"🔌 已关闭插件的群聊（共 {len(details)} 个）：", ""]
+        for item in details:
+            umo = item["umo"]
+            if item["permanent"]:
+                lines.append(f"  ⛔ {umo}\n     永久禁用")
+            else:
+                lines.append(f"  ⛔ {umo}\n     {self._format_switch_until(item['until'])}")
+        yield event.plain_result("\n".join(lines))
 
     def _parse_switch_action(self, message: str) -> str:
         """从开关命令消息中解析动作：on / off / status / （空）。"""
@@ -1588,7 +1655,7 @@ class CurrentCortexPlugin(Star):
             cleaned.strip(),
             flags=re.IGNORECASE,
         )
-        token = cleaned.strip().lower()
+        token = cleaned.strip().split()[0].lower() if cleaned.strip() else ""
         if token in ("on", "开", "enable", "启用"):
             return "on"
         if token in ("off", "关", "disable", "关闭", "禁用"):
@@ -1596,6 +1663,51 @@ class CurrentCortexPlugin(Star):
         if token in ("status", "状态", "查看", "query"):
             return "status"
         return ""
+
+    def _parse_switch_duration(self, message: str) -> Optional[float]:
+        """从开关命令消息中解析可选的禁用时长（秒），仅对 off 动作有意义。
+
+        支持形如 ``/开关 off 2h``、``/开关 关 30m``、``/开关 off 1d`` 的写法，
+        单位：s/秒、m/分/分钟、h/时/小时、d/天。未提供或格式无法识别时返回 None，
+        代表永久禁用（兼容旧版本 /开关 off 的行为，不影响老用户习惯）。
+        """
+        match = re.search(
+            r"(\d+(?:\.\d+)?)\s*(s|秒|m|分钟|分|h|时|小时|d|天)\b",
+            message.strip(),
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            return None
+        value = float(match.group(1))
+        unit = match.group(2).lower()
+        if unit in ("s", "秒"):
+            return value
+        if unit in ("m", "分钟", "分"):
+            return value * 60
+        if unit in ("h", "时", "小时"):
+            return value * 3600
+        if unit in ("d", "天"):
+            return value * 86400
+        return None
+
+    @staticmethod
+    def _format_switch_until(until: Optional[float]) -> str:
+        """将到期时间戳格式化为提示行；until 为 None 时给出永久禁用提示。"""
+        if until is None:
+            return "⏳ 永久禁用（需手动 /开关 on 恢复）"
+        import datetime as _dt
+
+        remain = max(0, until - time.time())
+        mins, secs = divmod(int(remain), 60)
+        hours, mins = divmod(mins, 60)
+        if hours:
+            remain_str = f"{hours}小时{mins}分钟后"
+        elif mins:
+            remain_str = f"{mins}分钟后"
+        else:
+            remain_str = f"{secs}秒后"
+        until_str = _dt.datetime.fromtimestamp(until).strftime("%m-%d %H:%M")
+        return f"⏳ 将于 {remain_str}（{until_str}）自动恢复"
 
     def _format_cross_group_record(self, event: AstrMessageEvent) -> str:
         """Format a group message into a single record line for cross-group memory.
@@ -1652,8 +1764,15 @@ class CurrentCortexPlugin(Star):
             platform_id = event.get_platform_id()
             if not platform_id:
                 return
+            max_age_seconds = (
+                self._cross_group_max_age_hours * 3600
+                if self._cross_group_max_age_hours > 0
+                else None
+            )
             shared = self._cross_group_store.get_recent(
-                platform_id, self._cross_group_inject_cnt
+                platform_id,
+                self._cross_group_inject_cnt,
+                max_age_seconds=max_age_seconds,
             )
             if not shared:
                 return
@@ -1668,6 +1787,50 @@ class CurrentCortexPlugin(Star):
             req.extra_user_content_parts.append(TextPart(text=block))
         except Exception as e:
             logger.error(f"[CrossGroupMemory] 注入上下文失败: {e}")
+
+    @filter.command("忘记", alias={"forget_memory", "忘记记忆"})
+    async def cross_group_forget_command(self, event: AstrMessageEvent):
+        """从跨群聊共享记忆中删除包含指定关键词的记录（仅管理员可用）。
+
+        用法：/忘记 <关键词>
+        会删除本平台跨群记忆中所有包含该关键词的记录行（子串匹配，不区分大小写），
+        用于清理误记录的内容，而不必用 /clear 之类的操作清空整个平台的记忆。
+        """
+        if not self._cross_group_enable or self._cross_group_store is None:
+            yield event.plain_result(
+                "❌ 跨群聊记忆功能未启用\n"
+                "💡 请在插件配置中开启 cross_group_enable 后重启插件"
+            )
+            return
+
+        if not event.is_admin():
+            yield event.plain_result("❌ 仅管理员可清理跨群聊记忆")
+            return
+
+        keyword = re.sub(
+            r"^[/!！]\s*(忘记|forget_memory|忘记记忆)\s*",
+            "",
+            event.message_str.strip(),
+            flags=re.IGNORECASE,
+        ).strip()
+        if not keyword:
+            yield event.plain_result("💡 用法：/忘记 <关键词>\n将删除跨群记忆中包含该关键词的所有记录")
+            return
+
+        platform_id = event.get_platform_id()
+        if not platform_id:
+            yield event.plain_result("❌ 无法获取当前平台标识，操作已取消")
+            return
+
+        removed = self._cross_group_store.forget_keyword(platform_id, keyword)
+        if removed:
+            logger.info(
+                f"[CrossGroupMemory] 用户 {event.get_sender_name()} "
+                f"删除了 {removed} 条包含关键词「{keyword}」的记录"
+            )
+            yield event.plain_result(f"✅ 已删除 {removed} 条包含「{keyword}」的记忆记录")
+        else:
+            yield event.plain_result(f"ℹ️ 未找到包含「{keyword}」的记忆记录")
 
     # =================================================================== #
     # 插件宣传（QQ 群）：/交流群 查询命令 + 帮助/错误提示末尾群号 +
@@ -4174,15 +4337,33 @@ class CurrentCortexPlugin(Star):
         except Exception as e:
             yield event.plain_result(f"抖音解析失败: {str(e)}")
 
+    @filter.command("weibo", alias={"微博"})
+    async def weibo_parse_command(self, event: AstrMessageEvent):
+        """解析微博链接中的媒体内容。"""
+        message_str = event.message_str.strip()
+        if self._is_help_command(message_str):
+            yield event.plain_result("微博解析: /weibo <链接>")
+            return
+        url = self._parse_media_url(message_str)
+        if not url or not URLExtractor.extract_weibo(url):
+            yield event.plain_result("请提供有效的微博链接")
+            return
+        try:
+            data = await self._media_parser.weibo.parse(url)
+            for item in self._format_weibo_response(data, event):
+                yield item
+        except Exception as e:
+            yield event.plain_result(f"微博解析失败: {str(e)}")
+
     def _parse_media_url(self, message: str) -> Optional[str]:
         cleaned = re.sub(
-            r"^[/!！]\s*(解析|xhs|小红书|bilibili|B站|b站|douyin|抖音)\s*",
+            r"^[/!！]\s*(解析|xhs|小红书|bilibili|B站|b站|douyin|抖音|weibo|微博)\s*",
             "",
             message.strip(),
             flags=re.IGNORECASE,
         )
         cleaned = re.sub(
-            r"^(解析|xhs|小红书|bilibili|B站|b站|douyin|抖音)\s*",
+            r"^(解析|xhs|小红书|bilibili|B站|b站|douyin|抖音|weibo|微博)\s*",
             "",
             cleaned.strip(),
             flags=re.IGNORECASE,
@@ -4198,6 +4379,7 @@ class CurrentCortexPlugin(Star):
             cleaned.startswith("xhslink.com/")
             or cleaned.startswith("b23.tv/")
             or cleaned.startswith("v.douyin.com/")
+            or cleaned.startswith("t.cn/")
         ):
             return f"https://{cleaned}"
         return None
@@ -4211,6 +4393,8 @@ class CurrentCortexPlugin(Star):
             return self._format_bilibili_response(data, event)
         elif platform == "douyin":
             return self._format_douyin_response(data, event)
+        elif platform == "weibo":
+            return self._format_weibo_response(data, event)
         return [event.plain_result("未知平台")]
 
     def _format_xiaohongshu_response(
@@ -4322,6 +4506,42 @@ class CurrentCortexPlugin(Star):
         results = [event.plain_result("\n".join(parts))]
         if cover:
             results.append(event.image_result(cover))
+        return results
+
+    def _format_weibo_response(
+        self, data: Dict[str, Any], event: AstrMessageEvent
+    ) -> List[Any]:
+        text = data.get("text", "")
+        author = data.get("author", "")
+        reposts = data.get("reposts", "")
+        comments = data.get("comments", "")
+        likes = data.get("likes", "")
+        images = data.get("images", [])
+        video_url = data.get("video_url", "")
+        url = data.get("url", "")
+        parts = ["📰 微博解析"]
+        if author:
+            parts.append(f"👤 作者：{author}")
+        stat_parts = []
+        if likes:
+            stat_parts.append(f"❤️ {likes}")
+        if comments:
+            stat_parts.append(f"💬 {comments}")
+        if reposts:
+            stat_parts.append(f"🔄 {reposts}")
+        if stat_parts:
+            parts.append(" ".join(stat_parts))
+        if text:
+            parts.append(f"📄 正文：{text[:200]}")
+        if url:
+            parts.append(f"🔗 链接：{url}")
+        if video_url:
+            parts.append(f"📥 视频：{video_url}")
+        results = [event.plain_result("\n".join(parts))]
+        if images:
+            for img_url in images[:9]:
+                if img_url:
+                    results.append(event.image_result(img_url))
         return results
 
     @staticmethod

--- a/media_parser.py
+++ b/media_parser.py
@@ -40,6 +40,14 @@ class URLExtractor:
         re.compile(r"https?://(?:www\.)?iesdouyin\.com/share/video/(\d+)"),
     ]
 
+    # 微博链接模式（含普通网页版微博正文、m 站移动版、短链）
+    WEIBO_PATTERNS = [
+        re.compile(r"https?://(?:www\.)?weibo\.com/\d+/([a-zA-Z0-9]+)"),
+        re.compile(r"https?://m\.weibo\.cn/(?:detail|status)/([a-zA-Z0-9]+)"),
+        re.compile(r"https?://weibo\.cn/status/([a-zA-Z0-9]+)"),
+        re.compile(r"https?://t\.cn/([a-zA-Z0-9]+)"),
+    ]
+
     @classmethod
     def extract_xiaohongshu(cls, text: str) -> Optional[str]:
         """提取小红书笔记ID"""
@@ -72,6 +80,15 @@ class URLExtractor:
         return None
 
     @classmethod
+    def extract_weibo(cls, text: str) -> Optional[str]:
+        """提取微博帖子ID（mid，或 t.cn 短链的短码，短链需再跳转解析）"""
+        for pattern in cls.WEIBO_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                return match.group(1)
+        return None
+
+    @classmethod
     def detect_platform(cls, text: str) -> Optional[str]:
         """检测链接所属平台"""
         if cls.extract_xiaohongshu(text):
@@ -80,6 +97,8 @@ class URLExtractor:
             return "bilibili"
         if cls.extract_douyin(text):
             return "douyin"
+        if cls.extract_weibo(text):
+            return "weibo"
         return None
 
 
@@ -615,6 +634,128 @@ class DouyinParser(BaseMediaParser):
         return result
 
 
+class WeiboParser(BaseMediaParser):
+    """微博内容解析器"""
+
+    def __init__(self, timeout: int = 20):
+        super().__init__(timeout)
+        self._headers["Referer"] = "https://m.weibo.cn/"
+
+    async def parse(self, url_or_text: str) -> Dict[str, Any]:
+        """解析微博链接"""
+        mid = URLExtractor.extract_weibo(url_or_text)
+        if not mid:
+            raise MediaParserError("未能从微博链接中提取到帖子ID，请检查链接格式")
+
+        # t.cn 短链需要先跳转拿到真实 mid
+        if "t.cn/" in url_or_text:
+            mid = await self._resolve_short_link(url_or_text)
+
+        return await self._fetch_post_detail(mid, url_or_text)
+
+    async def _resolve_short_link(self, short_url: str) -> str:
+        """解析微博 t.cn 短链，返回最终 URL 中的帖子 ID"""
+        async with aiohttp.ClientSession(
+            timeout=self._timeout, headers=self._headers
+        ) as session:
+            try:
+                async with session.get(
+                    short_url, allow_redirects=True, ssl=False
+                ) as resp:
+                    final_url = str(resp.url)
+                    mid = URLExtractor.extract_weibo(final_url)
+                    if mid:
+                        return mid
+            except Exception as e:
+                logger.error(f"[Weibo] 短链接解析失败: {e}")
+        raise MediaParserError("微博短链接解析失败，请使用完整链接")
+
+    async def _fetch_post_detail(self, mid: str, original_url: str) -> Dict[str, Any]:
+        """通过移动版接口获取微博详情，失败时回退到网页 og 标签解析"""
+        api_url = f"https://m.weibo.cn/statuses/show?id={mid}"
+        try:
+            data = await self._fetch_json(api_url)
+            payload = data.get("data") if isinstance(data, dict) else None
+            if payload:
+                return self._parse_status_payload(payload, mid, original_url)
+        except MediaParserError as e:
+            logger.error(f"[Weibo] API 获取失败，尝试网页兜底: {e}")
+
+        try:
+            html = await self._fetch_text(f"https://m.weibo.cn/detail/{mid}")
+            return self._parse_html_fallback(html, mid, original_url)
+        except MediaParserError as e:
+            logger.error(f"[Weibo] 网页兜底也失败: {e}")
+
+        return {
+            "mid": mid,
+            "title": "",
+            "text": "",
+            "author": "",
+            "images": [],
+            "url": original_url,
+        }
+
+    @staticmethod
+    def _strip_html_tags(text: str) -> str:
+        return re.sub(r"<[^>]+>", "", text or "").strip()
+
+    def _parse_status_payload(
+        self, payload: Dict[str, Any], mid: str, original_url: str
+    ) -> Dict[str, Any]:
+        """解析 m.weibo.cn statuses/show 接口返回的 JSON 结构"""
+        user = payload.get("user", {}) if isinstance(payload.get("user"), dict) else {}
+        pics = payload.get("pics", [])
+        images = []
+        if isinstance(pics, list):
+            for pic in pics:
+                pic_url = pic.get("large", {}).get("url") if isinstance(pic, dict) else None
+                if pic_url:
+                    images.append(pic_url)
+
+        page_info = payload.get("page_info", {})
+        video_url = ""
+        if isinstance(page_info, dict) and page_info.get("type") == "video":
+            media_info = page_info.get("media_info", {})
+            video_url = media_info.get("stream_url_hd") or media_info.get("stream_url", "")
+
+        return {
+            "mid": mid,
+            "text": self._strip_html_tags(payload.get("text", "")),
+            "author": user.get("screen_name", ""),
+            "reposts": str(payload.get("reposts_count", "")),
+            "comments": str(payload.get("comments_count", "")),
+            "likes": str(payload.get("attitudes_count", "")),
+            "images": images,
+            "video_url": video_url,
+            "url": original_url or f"https://m.weibo.cn/detail/{mid}",
+        }
+
+    def _parse_html_fallback(
+        self, html: str, mid: str, original_url: str
+    ) -> Dict[str, Any]:
+        """从网页 og 标签中兜底提取基础信息"""
+        result = {
+            "mid": mid,
+            "text": "",
+            "author": "",
+            "images": [],
+            "video_url": "",
+            "url": original_url or f"https://m.weibo.cn/detail/{mid}",
+        }
+        og_title = re.search(
+            r'<meta[^>]+property="og:title"[^>]+content="([^"]+)"', html
+        )
+        og_image = re.search(
+            r'<meta[^>]+property="og:image"[^>]+content="([^"]+)"', html
+        )
+        if og_title:
+            result["text"] = og_title.group(1)
+        if og_image:
+            result["images"] = [og_image.group(1)]
+        return result
+
+
 class MediaParserManager:
     """媒体解析管理器"""
 
@@ -622,6 +763,7 @@ class MediaParserManager:
         self.xiaohongshu = XiaoHongShuParser(timeout)
         self.bilibili = BilibiliParser(timeout)
         self.douyin = DouyinParser(timeout)
+        self.weibo = WeiboParser(timeout)
 
     async def parse(self, url_or_text: str) -> Dict[str, Any]:
         """自动识别平台并解析"""
@@ -639,7 +781,9 @@ class MediaParserManager:
             }
         elif platform == "douyin":
             return {"platform": "douyin", "data": await self.douyin.parse(url_or_text)}
+        elif platform == "weibo":
+            return {"platform": "weibo", "data": await self.weibo.parse(url_or_text)}
         else:
             raise MediaParserError(
-                "未能识别链接所属平台，请检查链接格式是否支持（小红书/B站/抖音）"
+                "未能识别链接所属平台，请检查链接格式是否支持（小红书/B站/抖音/微博）"
             )


### PR DESCRIPTION
## 改动类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 💥 破坏性变更
- [ ] 📝 文档更新
- [ ] 🔧 重构
- [ ] ✅ 测试补充

## 自测清单

- [x] 本地运行过相关测试（`python3 test_memory_and_switch.py`，15 项通过）
- [] 涉及命令交互的改动已在真实平台（QQ 等）手动验证
- [ ] 改动了配置项 / 命令用法的，已同步更新 `README.md` 与 `_conf_schema.json`
- [ ] 有用户可见变更的，已在 `CHANGELOG.md` 的 `[Unreleased]` 小节追加条目
- [ ] 新增测试文件已在 `.gitignore` 白名单中登记（`!test_memory_and_switch.py`）
- [x] 未引入新的第三方依赖

---

## 新增功能

### 1. 跨群聊记忆：时效过滤 + 话题标签 + 关键词遗忘

**改动**
- `record()` / `get_recent()` 新增可选参数：
  - `tag`：记录话题标签，`get_recent(tag=...)` 可只取某一话题的记忆
  - `max_age_seconds`：只返回该时长内的记录，避免冷群翻出陈年旧话题
- 新增 `forget_keyword(platform_id, keyword)`：按关键词删除记忆中的指定记录，无需 `clear()` 整体清空
- 新增配置项 `cross_group_max_age_hours`（默认 0 = 不限时效，保持旧行为不变）
- 新增指令 `/忘记 <关键词>`（管理员可用）
- 记录结构从纯字符串升级为 `{ts, tag, content}`，**加载时自动兼容迁移旧格式**，不影响老用户已有数据

**收益**：注入 LLM 的共享上下文不再单纯依赖消息量裁剪，冷群不会把过时话题带回来；出现误记录时可以精确清理，而不必牺牲整个平台的记忆。

**怎么用**

在插件配置里打开跨群聊记忆功能：
```

cross_group_enable: true
cross_group_max_age_hours: 24   # 例如只保留最近24小时的共享记忆，0表示不限

```

清理误记录的内容（群里管理员发送）：
```

/忘记 某个不该记住的词

```
机器人会回复删除了多少条包含该关键词的记录。

**怎么测试**

1. 打开 `cross_group_enable`，重启插件
2. 在群 A 发几条消息，在群 B（同平台实例下）发起对话，确认 LLM 回复里能体现群 A 的上下文（说明共享注入生效）
3. 把 `cross_group_max_age_hours` 设为一个很小的值（比如 1），等超过这个时长后再触发对话，确认旧记录不再被注入
4. 发送 `/忘记 <关键词>`，确认对应记录被清除，且后续对话不会再引用被删除的内容
5. 运行单元测试：
   ```bash
   python3 test_memory_and_switch.py
```

应看到 15 通过, 0 失败

---

2. 按群开关：定时禁用 + 可视化列表

改动

· set_disabled(umo, duration_seconds=...)：支持限时禁用，到期后懒惰过期自动恢复（判断时才清理，不需要额外后台任务/定时器）
· 新增 get_until()、list_disabled_detail()
· 指令升级：/开关 off 2h（支持 s/m/h/d 及中文单位：秒/分钟/小时/天），/开关 status 会显示剩余恢复时间
· 新增管理员指令 /开关列表：文本表格展示当前平台下所有被关闭插件的群聊及各自恢复时间
· 存储格式向后兼容：旧版本 {"disabled": [...]} 列表格式自动迁移为新结构（全部视为永久禁用）

收益：类似"晚 10 点后免打扰、早 8 点自动恢复"的场景不再需要人工每天手动切换；管理员也不用逐群 /开关 status 查询，一条命令看全貌。

怎么用

在某个群里（需要管理员权限，除非关闭了 group_switch_admin_only）：

```
/开关 off        # 永久关闭本群插件（旧用法，不受影响）
/开关 off 2h     # 关闭2小时，到期自动恢复
/开关 off 30m    # 关闭30分钟
/开关 off 1d     # 关闭1天
/开关 status     # 查看当前状态及剩余恢复时间
/开关 on         # 手动提前恢复
```

查看当前平台下所有被关闭的群（管理员）：

```
/开关列表
```

怎么测试

1. 在一个测试群发送 /开关 off 10s（用短时长方便验证）
2. 立刻发送任意其他指令，确认被静默拦截（不响应）
3. 发送 /开关 status，确认显示"约10秒后自动恢复"之类的提示
4. 等待 10 秒以上，再次发送指令，确认已自动恢复响应
5. 用管理员账号发送 /开关列表，确认列表能正确显示当前所有被禁用的群及恢复时间（测试期间如有其他群被禁用也会一并列出）
6. 单元测试同样覆盖了这部分逻辑（定时恢复、列表详情、旧格式迁移），见 test_memory_and_switch.py 中 test_timed_disable_auto_recovers、test_list_disabled_detail、test_legacy_list_format_migration

---

3. 媒体解析：新增微博支持

改动

· URLExtractor 新增 extract_weibo()，覆盖 weibo.com、m.weibo.cn（detail/status）、weibo.cn、t.cn 短链
· 新增 WeiboParser：优先走 m.weibo.cn 移动端接口，失败时自动降级到网页 og 标签兜底解析
· 新增指令 /weibo（别名 /微博），并接入自动识别指令 /解析
· 更新帮助文本 MEDIA_PARSER_HELP_TEXT

收益：群内分享微博链接时机器人也能正常识别解析，不再是"支持三个平台，唯独微博当纯文本处理"的体验断层。

怎么用

```
/weibo https://m.weibo.cn/detail/xxxxx     # 直接解析
/微博 https://weibo.com/1234567890/xxxxx   # 别名同样可用
/解析 <任意支持平台的链接>                   # 自动识别，微博链接同样支持
```

会返回正文摘要、作者、转发/评论/点赞数、配图（最多9张）及视频链接（如有）。

怎么测试

1. 找一条真实的微博帖子链接（网页版、m 站或 t.cn 短链任选），发送 /weibo <链接>，确认能正常返回正文、作者等信息和配图
2. 发送 /解析 <同一条微博链接>，确认自动识别路径同样能正确解析（走的是同一个 MediaParserManager）
3. 故意发一个格式错误或无效的微博链接，确认返回"请提供有效的微博链接"而不是报错崩溃
4. 发送 /解析 help，确认帮助文本里已经包含微博的使用说明
5. 纯逻辑部分（URL 提取正则、JSON 解析、HTML 兜底解析）已通过本地 mock 测试验证，无需真实网络请求即可确认；但实际接口返回结构可能随微博改版变化，建议合并前用几条真实链接跑一遍人工验证，因为这部分没有接入自动化测试（需要网络访问）

---

改动文件

文件 改动类型
cross_group_memory.py 重写（新增字段与方法，向后兼容旧数据）
group_switch_store.py 重写（新增定时能力，向后兼容旧数据）
media_parser.py 新增 WeiboParser 及相关正则/分发逻辑
main.py 新增/调整多条指令处理逻辑，更新帮助文本，更新配置读取
_conf_schema.json 新增 cross_group_max_age_hours 配置项
test_memory_and_switch.py 新增，15 项回归测试全部通过

兼容性说明

· 所有改动均为加法式（新参数带默认值、新方法、新指令），未修改任何既有函数签名的必填参数，不影响已有调用方
· 两个存储模块的持久化格式升级均带自动迁移逻辑，旧版本数据文件可直接被新代码读取，无需手动转换
· 默认配置下（cross_group_max_age_hours=0），跨群记忆行为与升级前完全一致

自动化测试

```bash
python3 test_memory_and_switch.py
# 15 通过, 0 失败
```

若要跑项目自带的 test_reply_seg.py，需要插件目录在磁盘上命名为 astrbot_plugin_pixiv（历史遗留约定，非本 PR 引入），可用软链接绕过：

```bash
cd <项目上级目录>
ln -s <你的目录名> astrbot_plugin_pixiv
cd astrbot_plugin_pixiv
python3 test_reply_seg.py
python3 test_memory_and_switch.py
```

微博解析部分因涉及真实网络请求未纳入自动化测试，请求合并前人工验证一下（见上方"怎么测试"部分）。